### PR TITLE
Add missing meta viewport tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<title>Disney Open Source</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link href="./stylesheets/font.css" rel="stylesheet" type="text/css">
 		<link href="./stylesheets/layout.css" media="all" rel="stylesheet" type="text/css">
 		<link href="./images/favicon.ico" rel="icon">


### PR DESCRIPTION
disney.github.io is missing a valid [viewport metatag](https://developers.google.com/speed/docs/insights/ConfigureViewport). Without this specified, mobile browsers can render the page with a fallback width that ranges from 800 to 1034 CSS pixels, forcing folks to zoom out before they can interact with the page.

Below is an example of the behavior this PR tries to avoid:
![screen shot 2016-10-17 at 3 48 14 pm](https://cloud.githubusercontent.com/assets/110953/19458499/4f54af04-9481-11e6-87f5-1d40022c9cb6.jpg)
