### PR TITLE
Drop duplicate reference to jQuery CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,8 +267,7 @@
 				</div>
 			</div>
 		</div>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-1.12.4.js"></script>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-1.12.4.min.js"></script>
+		<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
 		<script type="text/javascript" src="./slick/slick.min.js"></script>
 		<script type="text/javascript">
 			$(document).ready(function(){


### PR DESCRIPTION
jQuery is referenced twice in the current disney.github.io - once in unminified form and another in minified form:

![](https://i.imgur.com/TzlW13O.jpg)

This PR drops the first of these and also switches over to the HTTPS version of jQuery hosted on their CDN.