### PR TITLE
Add support for Google Tag Manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,13 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 	<head>
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-KHNSCWN');</script>
+		<!-- End Google Tag Manager -->
                 <!-- Global site tag (gtag.js) - Google Analytics -->
                 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112951814-1"></script>
                 <script>
@@ -20,6 +27,10 @@
 		<link rel="stylesheet" type="text/css" href="./slick/slick-theme.css"/>
 	</head>
 	<body data-action="open_source" data-controller="Technology">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KHNSCWN"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 		<div class="content-wrapper">
 			<div class="main-site" id="main-site">
 				<header class="site-header">


### PR DESCRIPTION
Adding support for GTM will enable Google Analytics to track outbound link clicks, so we can see which projects are accessed.