### PR TITLE
Removing inactive projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,21 +227,6 @@
 								</div>
 							</article>
 							<article class="open-source">
-								<div class="open-source-image">
-									<img alt="Reposado image" src="./images/reposado_logo.png" width="255" height="130">
-								</div>
-								<div class="open-source-content">
-									<span class="open-source-bu">Reposado</span>
-									<p class="open-source-body">Reposado is a set of tools written in Python that replicate the key functionality of Mac OS X Server's Software Update Service. Reposado, together with the "curl" binary tool and a web server such as Apache 2, enables you to host a local Apple Software Update Server on any hardware and OS of your choice.</p>
-									<div class="open-source-read-link">
-										<div class="github-link">
-											<a title="Github page" href="https://github.com/wdas/reposado" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
-										</div>
-										<a title="More information" href="https://github.com/wdas/reposado" target="_blank">more</a>
-									</div>
-								</div>
-							</article>
-							<article class="open-source">
 								<div class="open-source-image no-img">
 									<span>jss-api-gem</span>
 								</div>
@@ -313,36 +298,6 @@
 											<a title="Github page" href="https://github.com/wdas/partio/" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
 										</div>
 										<a title="More information" href="http://www.disneyanimation.com/technology/partio.html" target="_blank">more</a>
-									</div>
-								</div>
-							</article>
-							<article class="open-source">
-								<div class="open-source-image">
-									<img alt="Dynamica logo" src="./images/dynamica_logo.png" width="255" height="130">
-								</div>
-								<div class="open-source-content">
-									<span class="open-source-bu">Dynamica</span>
-									<p class="open-source-body">Dynamica is a plug-in for Maya that provides an interface to the Bullet rigid body engine. Bullet was originally created to simulate many rigid bodies quickly in a game context, but this plug-in helps extend its usefulness to film production. The Walt Disney Animation Studios used this plug-in to model the thousands of packing peanuts seen in BOLT.</p>
-									<div class="open-source-read-link">
-										<div class="source-link">
-											<a title="Source page" href="https://code.google.com/archive/p/dynamica/source/default/source" target="_blank">Source</a>
-										</div>
-										<a title="More information" href="http://www.bulletphysics.org/mediawiki-1.5.8/index.php/Maya_Dynamica_Plugin" target="_blank">more</a>
-									</div>
-								</div>
-							</article>
-							<article class="open-source">
-								<div class="open-source-image">
-									<img alt="BRDF Explorer logo" src="./images/brdf_logo.png" width="255" height="130">
-								</div>
-								<div class="open-source-content">
-									<span class="open-source-bu">BRDF Explorer</span>
-									<p class="open-source-body">BRDF Explorer is an application that allows the development and analysis of bidirectional reflectance distribution functions (BRDFs). It can plot both analytic BRDF functions and measured material data. Graphs and visualizations update in realtime as parameters are changed, making it a useful tool for evaluating and understanding different BRDFs (and other component functions).</p>
-									<div class="open-source-read-link">
-										<div class="github-link">
-											<a title="Github page" href="https://github.com/wdas/brdf" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
-										</div>
-										<a title="More information" href="http://www.disneyanimation.com/technology/brdf.html" target="_blank">more</a>
 									</div>
 								</div>
 							</article>


### PR DESCRIPTION
This update removes older, inactive projects from the site. The project repositories remain in github.com, but will not be actively promoted here.