### PR TITLE
Update WDAS project page links

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
 										<div class="github-link">
 											<a title="Github page" href="https://github.com/PixarAnimationStudios/ruby-jss" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
 										</div>
-										<a title="More information" href="http://pixaranimationstudios.github.io/jss-api-gem/index.html" target="_blank">more</a>
+										<a title="More information" href="https://www.rubydoc.info/gems/ruby-jss/" target="_blank">more</a>
 									</div>
 								</div>
 							</article>
@@ -247,12 +247,12 @@
 								</div>
 								<div class="open-source-content">
 									<span class="open-source-bu">SeExpr</span>
-									<p class="open-source-body">SeExpr is a simple expression language that we use to provide artistic control and customization to our core software. We use it for procedural geometry synthesis, image synthesis, simulation control, and much more.</p>
+									<p class="open-source-body">SeExpr is an embeddable, arithmetic expression language that enables flexible artistic control and customization in creating computer graphics images. Example uses include procedural geometry synthesis, image synthesis, simulation control, crowd animation, and geometry deformation.</p>
 									<div class="open-source-read-link">
 										<div class="github-link">
 											<a title="Github page" href="https://github.com/wdas/seexpr/" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
 										</div>
-										<a title="More information" href="http://www.disneyanimation.com/technology/seexpr.html" target="_blank">more</a>
+										<a title="More information" href="https://wdas.github.io/SeExpr/" target="_blank">more</a>
 									</div>
 								</div>
 							</article>
@@ -277,7 +277,7 @@
 								</div>
 								<div class="open-source-content">
 									<span class="open-source-bu">Ptex</span>
-									<p class="open-source-body">Ptex is a texture mapping system for production-quality rendering. We present a simple generalized impact model motivated by both the successes and pitfalls of two popular approaches: pair-wise propagation and linear complementarity models. Our algorithm is the first to satisfy all identified desiderata, including simultaneously guaranteeing symmetry preservation, kinetic energy conservation, and allowing break-away.</p>
+									<p class="open-source-body">Ptex is a texture mapping system for production-quality rendering: No UV assignment is required! Ptex applies a separate texture to each face of a subdivision or polygon mesh. The Ptex file format can efficiently store hundreds of thousands of texture images in a single file. The Ptex API provides cached file I/O and high-quality filtering - everything that is needed to easily add Ptex support to a production-quality renderer or texture authoring application.</p>
 									<div class="open-source-read-link">
 										<div class="github-link">
 											<a title="Github page" href="http://github.com/wdas/ptex" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
@@ -292,12 +292,12 @@
 								</div>
 								<div class="open-source-content">
 									<span class="open-source-bu">Partio</span>
-									<p class="open-source-body">Partio is an open source C++ library for reading, writing and manipulating a variety of standard particle formats (GEO,BGEO,PTC,PDB,PDA). It also has a python API and a collection of simple command-line tools. Licensed under the BSD license.</p>
+									<p class="open-source-body">Partio is an open source C++ library for reading, writing and manipulating a variety of standard particle formats (GEO,BGEO,PTC,PDB,PDA). It also has a python API and a collection of simple command-line tools.</p>
 									<div class="open-source-read-link">
 										<div class="github-link">
 											<a title="Github page" href="https://github.com/wdas/partio/" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
 										</div>
-										<a title="More information" href="http://www.disneyanimation.com/technology/partio.html" target="_blank">more</a>
+										<a title="More information" href="http://partio.us/" target="_blank">more</a>
 									</div>
 								</div>
 							</article>
@@ -312,7 +312,7 @@
 										<div class="github-link">
 											<a title="Github page" href="https://github.com/dragonchain/dragonchain" target="_blank"><svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg></a>
 										</div>
-										<a title="More information" href="https://dragonchain.github.io/" target="_blank">more</a>
+										<a title="More information" href="https://dragonchain.org/" target="_blank">more</a>
 									</div>
 								</div>
 							</article>


### PR DESCRIPTION
WDAS has new pages for its open source projects. This PR brings disney.github.io up-to-date with their latest documentation links.